### PR TITLE
Better nick handling in 'repall'

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -531,7 +531,7 @@ def reply_all():
     original_tweet = t.statuses.show(id=tid)
     text = original_tweet['text']
     nick_ary = [original_tweet['user']['screen_name']]
-    for user in tweet['entities']['user_mentions']:
+    for user in list(original_tweet['entities']['user_mentions']):
         if user['screen_name'] not in nick_ary \
                 and user['screen_name'] != g['original_name']:
             nick_ary.append(user['screen_name'])

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -530,11 +530,14 @@ def reply_all():
     tid = c['tweet_dict'][id]
     original_tweet = t.statuses.show(id=tid)
     text = original_tweet['text']
-    owner = '@' + original_tweet['user']['screen_name']
-    nick_ary = ['@' + re.sub('[\W_]', '', w)
-                for w in text.split() if w.startswith('@')] + [owner]
+    nick_ary = [original_tweet['user']['screen_name']]
+    for user in tweet['entities']['user_mentions']:
+        if user['screen_name'] not in nick_ary:
+            nick_ary.append(user['screen_name'])
+    if g['original_name'] in nick_ary:
+        nick_ary.remove(g['original_name'])
     status = ' '.join(g['stuff'].split()[1:])
-    status = ' '.join(nick_ary) + ' ' + str2u(status)
+    status = ' '.join(['@' + nick for nick in nick_ary]) + ' ' + str2u(status)
     t.statuses.update(status=status, in_reply_to_status_id=tid)
 
 

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -532,10 +532,9 @@ def reply_all():
     text = original_tweet['text']
     nick_ary = [original_tweet['user']['screen_name']]
     for user in tweet['entities']['user_mentions']:
-        if user['screen_name'] not in nick_ary:
+        if user['screen_name'] not in nick_ary \
+                and user['screen_name'] != g['original_name']:
             nick_ary.append(user['screen_name'])
-    if g['original_name'] in nick_ary:
-        nick_ary.remove(g['original_name'])
     status = ' '.join(g['stuff'].split()[1:])
     status = ' '.join(['@' + nick for nick in nick_ary]) + ' ' + str2u(status)
     t.statuses.update(status=status, in_reply_to_status_id=tid)


### PR DESCRIPTION
I wrote [this reply](https://twitter.com/Tenzer/status/570997097400557569) by using the `repall` command, and as you can see it mentioned myself first. I had a look at the code behind it and made a few improvements:

1. Make sure the person who wrote the tweet we are replying to is mentioned first (unless it's the RS user).
2. Make sure we don't mention the RS user.
3. Make sure the same user isn't mentioned multiple times.

I also switched the previous nick parsing to use the entities list of the tweet. [Here's a link](https://dev.twitter.com/overview/api/entities-in-twitter-objects#user_mentions) to the documentation for that.