### PR TITLE
Check tweet length

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1941,13 +1941,15 @@ def listen():
             c['lock'] = True
             # Save cmd to global variable and call process
             g['stuff'] = ' '.join(line.split()[1:])
-            # Process the command
-            process(cmd)()
-            # Not re-display
-            if cmd in ['switch', 't', 'rt', 'rep']:
-                g['prefix'] = False
-            else:
-                g['prefix'] = True
+            # Check tweet length
+            if check_tweet_length():
+                # Process the command
+                process(cmd)()
+                # Not re-display
+                if cmd in ['switch', 't', 'rt', 'rep']:
+                    g['prefix'] = False
+                else:
+                    g['prefix'] = True
             # Release the semaphore lock
             c['lock'] = False
         except EOFError:
@@ -1955,6 +1957,18 @@ def listen():
         except Exception:
             debug_option()
             printNicely(red('OMG something is wrong with Twitter right now.'))
+
+
+def check_tweet_length():
+    """
+    Check tweet length (should be <= 140 chars)
+    """
+    length = len(g['stuff'])
+    if length <= 140:
+        return True
+
+    printNicely(red("Message is too long: %s chars" % length))
+    return False
 
 
 def reconn_notice():


### PR DESCRIPTION
Check the length of a tweet before sending to twitter and display error message
so user can change the message without having to wait for the twitter exception.

Closes #58 