### PR TITLE
Add Dockerfile for self-contained runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:2.7.9
+
+RUN pip install rainbowstream
+CMD rainbowstream


### PR DESCRIPTION
This addition creates a dockerfile which can be used as follows:
docker run --rm -i -t  YOURHUBNAME/rainbowstream

It is purposely self-contained, but one could mount the .rainbow_config.json and oauth files for persistence if wanted.