### PR TITLE
Fix issue #93 - uses re to parse links in tweet

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import re
 import sys
 import signal
 import argparse
@@ -643,13 +644,11 @@ def urlopen():
             return
         tid = c['tweet_dict'][int(g['stuff'])]
         tweet = t.statuses.show(id=tid)
-        link_prefix = ('http://', 'https://')
-        link_ary = [u for u in tweet['text'].split()
-                    if u.startswith(link_prefix)]
-        if not link_ary:
+        links = re.findall(r'https?\:\/\/t\.co\/[a-zA-Z0-9]{10}', tweet['text'])
+        if links is None:
             printNicely(light_magenta('No url here @.@!'))
             return
-        for link in link_ary:
+        for link in links:
             webbrowser.open(link)
     except:
         debug_option()


### PR DESCRIPTION
Before this, the **open {id}** command was using only *prefix-matching* to parse links from tweets.
In old way, it used to split the tweet text and collected all the words with *http/https* as prefix.

As explained in a sample tweet in issue #93:
> Super excited to have David DeSandro (@desandro) helping us revamp forecast.io (soon to be http://darksky.net).

The parsed links here, will be 'http://darksky.net).' instead of 'http://darksky.net', which is wrong.

Now it uses regex module to parse the same.

As shortened URLs in tweets have 22/23 string length(based on protocol). So, all the short URLs have unique-id of length 10 as suffix.

So, a simple **re.findall** with *https?\:\/\/t\.co\/[a-zA-Z0-9]{10}* as search pattern, will return a list of all the links in the tweet text.

That's it. :octocat: 