### PR TITLE
Better images

### DIFF
--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -54,7 +54,6 @@ def image_to_display(path, start=None, length=None):
     i.load()
     width = min(w, length)
     height = int(float(h) * (float(width) / float(w)))
-    height //= 2
     i = i.resize((width, height), Image.ANTIALIAS)
     height = min(height, c['IMAGE_MAX_HEIGHT'])
 

--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -31,12 +31,21 @@ def pixel_print(ansicolor):
     sys.stdout.write('\033[48;5;%sm \033[0m' % (ansicolor))
 
 
-def block_print(lower, higher):
+def block_print(higher, lower):
     """
     Print two pixels arranged above each other with Ansi color.
     Abuses Unicode to print two pixels in the space of one terminal block.
     """
-    sys.stdout.write('\033[38;5;%sm\033[48;5;%sm▄\033[0m' % (higher, lower))
+    r0, g0, b0 = lower[:3]
+    r1, g1, b1 = higher[:3]
+
+    if c['24BIT'] is True:
+        sys.stdout.write('\033[38;2;%d;%d;%dm\033[48;2;%d;%d;%dm▄\033[0m'
+                         % (r1, g1, b1, r0, g0, b0))
+    else:
+        i0 = rgb2short(r0, g0, b0)
+        i1 = rgb2short(r1, g1, b1)
+        sys.stdout.write('\033[38;5;%sm\033[48;5;%sm▄\033[0m' % (i1, i0))
 
 
 def image_to_display(path, start=None, length=None):
@@ -63,9 +72,7 @@ def image_to_display(path, start=None, length=None):
             y = real_y * 2
             p0 = i.getpixel((x, y))
             p1 = i.getpixel((x, y+1))
-            r0, g0, b0 = p0[:3]
-            r1, g1, b1 = p1[:3]
-            block_print(rgb2short(r0, g0, b0), rgb2short(r1, g1, b1))
+            block_print(p1, p0)
         sys.stdout.write('\n')
 
 

--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -24,10 +24,12 @@ def call_c():
 rgb2short = call_c()
 
 
-def pixel_print(ansicolor):
+def pixel_print(pixel):
     """
     Print a pixel with given Ansi color
     """
+    r, g, b = pixel[:3]
+    ansicolor = rgb2short(r, g, b)
     sys.stdout.write('\033[48;5;%sm \033[0m' % (ansicolor))
 
 
@@ -63,17 +65,27 @@ def image_to_display(path, start=None, length=None):
     i.load()
     width = min(w, length)
     height = int(float(h) * (float(width) / float(w)))
+    if c['HIGHER_RESOLUTION'] is False:
+        height //= 2
     i = i.resize((width, height), Image.ANTIALIAS)
     height = min(height, c['IMAGE_MAX_HEIGHT'])
 
-    for real_y in xrange(height // 2):
-        sys.stdout.write(' ' * start)
-        for x in xrange(width):
-            y = real_y * 2
-            p0 = i.getpixel((x, y))
-            p1 = i.getpixel((x, y+1))
-            block_print(p1, p0)
-        sys.stdout.write('\n')
+    if c['HIGHER_RESOLUTION'] is True:
+        for real_y in xrange(height // 2):
+            sys.stdout.write(' ' * start)
+            for x in xrange(width):
+                y = real_y * 2
+                p0 = i.getpixel((x, y))
+                p1 = i.getpixel((x, y+1))
+                block_print(p1, p0)
+            sys.stdout.write('\n')
+    else:
+        for y in xrange(height):
+            sys.stdout.write(' ' * start)
+            for x in xrange(width):
+                p = i.getpixel((x, y))
+                pixel_print(p)
+            sys.stdout.write('\n')
 
 
 """

--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -31,6 +31,14 @@ def pixel_print(ansicolor):
     sys.stdout.write('\033[48;5;%sm \033[0m' % (ansicolor))
 
 
+def block_print(lower, higher):
+    """
+    Print two pixels arranged above each other with Ansi color.
+    Abuses Unicode to print two pixels in the space of one terminal block.
+    """
+    sys.stdout.write('\033[38;5;%sm\033[48;5;%sm▄\033[0m' % (higher, lower))
+
+
 def image_to_display(path, start=None, length=None):
     """
     Display an image
@@ -50,12 +58,15 @@ def image_to_display(path, start=None, length=None):
     i = i.resize((width, height), Image.ANTIALIAS)
     height = min(height, c['IMAGE_MAX_HEIGHT'])
 
-    for y in xrange(height):
+    for real_y in xrange(height // 2):
         sys.stdout.write(' ' * start)
         for x in xrange(width):
-            p = i.getpixel((x, y))
-            r, g, b = p[:3]
-            pixel_print(rgb2short(r, g, b))
+            y = real_y * 2
+            p0 = i.getpixel((x, y))
+            p1 = i.getpixel((x, y+1))
+            r0, g0, b0 = p0[:3]
+            r1, g1, b1 = p1[:3]
+            block_print(rgb2short(r0, g0, b0), rgb2short(r1, g1, b1))
         sys.stdout.write('\n')
 
 

--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -29,8 +29,13 @@ def pixel_print(pixel):
     Print a pixel with given Ansi color
     """
     r, g, b = pixel[:3]
-    ansicolor = rgb2short(r, g, b)
-    sys.stdout.write('\033[48;5;%sm \033[0m' % (ansicolor))
+
+    if c['24BIT'] is True:
+        sys.stdout.write('\033[48;2;%d;%d;%dm \033[0m'
+                         % (r, g, b))
+    else:
+        ansicolor = rgb2short(r, g, b)
+        sys.stdout.write('\033[48;5;%sm \033[0m' % (ansicolor))
 
 
 def block_print(higher, lower):

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -68,6 +68,11 @@ def parse_arguments():
         action='store_true',
         help='Display all image on terminal.')
     parser.add_argument(
+        '-24',
+        '--color-24bit',
+        action='store_true',
+        help='Display images using 24bit color codes.')
+    parser.add_argument(
         '-ph',
         '--proxy-host',
         help='Use HTTP/SOCKS proxy for network connections.')
@@ -233,6 +238,7 @@ def init(args):
     c['message_dict'] = []
     # Image on term
     c['IMAGE_ON_TERM'] = args.image_on_term
+    c['24BIT'] = args.color_24bit
     set_config('IMAGE_ON_TERM', str(c['IMAGE_ON_TERM']))
     # Check type of ONLY_LIST and IGNORE_LIST
     if not isinstance(c['ONLY_LIST'], list):
@@ -1291,7 +1297,7 @@ def switch():
             return
         # Kill old thread
         g['stream_stop'] = True
-        try: 
+        try:
             stuff = g['stuff'].split()[1]
         except:
             stuff = None

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -73,6 +73,11 @@ def parse_arguments():
         action='store_true',
         help='Display images using 24bit color codes.')
     parser.add_argument(
+        '-hr',
+        '--higher-resolution',
+        action='store_true',
+        help='Display images in high(er) resolution.')
+    parser.add_argument(
         '-ph',
         '--proxy-host',
         help='Use HTTP/SOCKS proxy for network connections.')
@@ -238,8 +243,12 @@ def init(args):
     c['message_dict'] = []
     # Image on term
     c['IMAGE_ON_TERM'] = args.image_on_term
-    c['24BIT'] = args.color_24bit
     set_config('IMAGE_ON_TERM', str(c['IMAGE_ON_TERM']))
+    # Use 24 bit color
+    c['24BIT'] = args.color_24bit
+    # Print images using half height blocks
+    c['HIGHER_RESOLUTION'] = args.higher_resolution
+    set_config('HIGHER_RESOLUTION', str(c['HIGHER_RESOLUTION']))
     # Check type of ONLY_LIST and IGNORE_LIST
     if not isinstance(c['ONLY_LIST'], list):
         printNicely(red('ONLY_LIST is not a valid list value.'))


### PR DESCRIPTION
Hi!
These changes add two additional flags for better image-on-term support

* -hr enables higher resolution images by printing two pixels for every printable character; doubling the resolution of displayed images
* -24 enables 24bit color output.  This lets (on terminals like iTerm and VTE that support it) images be displayed using true colors, rather than the more limited 256 color palette.

I've attached a screen shot showing them both enabled, but they work fine independent of each other too.
![screen shot 2015-07-31 at 12 00 30 am](https://cloud.githubusercontent.com/assets/658598/8997253/3e6e24f4-3717-11e5-9211-813cacfb1bcb.png)

Image printing method was copied from [icat](https://github.com/atextor/icat).

This is my first pull request, so apologies if I have made a mistake.
Let me know and I'll try and fix them :-D