### PR TITLE
Image resizing for tall images.

### DIFF
--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -71,6 +71,17 @@ def image_to_display(path, start=None, length=None):
     i.load()
     width = min(w, length)
     height = int(float(h) * (float(width) / float(w)))
+
+    if c['IMAGE_RESIZE_TO_FIT'] is True:
+        # If it image won't fit in the terminal without scrolling shrink it
+        # Subtract 3 from rows so the tweet message fits in too.
+        h = 2 * (int(rows) - 3)
+        if height >= h:
+            width = int(float(width) * (float(h) / float(height)))
+            height = h
+    if (height <= 0) or (width <= 0):
+        raise ValueError("image has negative dimensions")
+
     i = i.resize((width, height), Image.ANTIALIAS)
     height = min(height, c['IMAGE_MAX_HEIGHT'])
 

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -242,6 +242,8 @@ def init(args):
     set_config('IMAGE_ON_TERM', str(c['IMAGE_ON_TERM']))
     # Use 24 bit color
     c['24BIT'] = args.color_24bit
+    # Resize images based on the current terminal size
+    set_config('IMAGE_RESIZE_TO_FIT', str(c.get('IMAGE_RESIZE_TO_FIT', False)))
     # Check type of ONLY_LIST and IGNORE_LIST
     if not isinstance(c['ONLY_LIST'], list):
         printNicely(red('ONLY_LIST is not a valid list value.'))


### PR DESCRIPTION
Adds a config option (IMAGE_RESIZE_TO_FIT) that, if set, causes images to be resized so they fit fully within the terminal window.  Current behaviour (which is kept by default) is to fit to width then make the user scroll.

It was annoying me today when I had rainbowstream open fullscreen on a widescreen monitor I kept having to scroll to see the whole image (I have IMAGE_MAX_HEIGHT set very large so I can see everything); so I thought I'd make another little patch. 

Screen shot showing behaviour with IMAGE_RESIZE_TO_FIT set to true below.

![screen shot 2015-08-04 at 10 52 50 pm](https://cloud.githubusercontent.com/assets/658598/9073901/b4c3a28a-3afc-11e5-824a-92db7dc02b1d.png)
