### PR TITLE
Fixed issue #149, stream hangup bug

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1959,8 +1959,6 @@ def listen():
                 g['prefix'] = False
             else:
                 g['prefix'] = True
-            # Release the semaphore lock
-            c['lock'] = False
         except EOFError:
             printNicely('')
         except TwitterHTTPError as e:
@@ -1968,6 +1966,9 @@ def listen():
         except Exception:
             debug_option()
             printNicely(red('OMG something is wrong with Twitter API right now.'))
+        finally:
+            # Release the semaphore lock
+            c['lock'] = False
 
 
 def reconn_notice():


### PR DESCRIPTION
Finally fixed [this](https://github.com/DTVD/rainbowstream/issues/149) bug. It was a lot simpler than I thought it would be; an exception occurring at the `process` call in `listen` would cause the `pause` flag to not be reset, which would make the generator in `stream` hang until a successful call to `process`, which would reset the flag. Moving the flag reset to a finally block clears it up.