### PR TITLE
Set configuration file ownership

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup, find_packages
 import os
 import os.path
+import sys
+
+if sys.version[0] == "2":
+    from pipes import quote
+else:
+    from shlex import quote
 
 # Bumped version
 version = '1.3.3'
@@ -16,10 +22,15 @@ install_requires = [
     "PySocks"
 ]
 
+# Default user (considers non virtualenv method)
+user = os.environ.get('SUDO_USER', os.environ['USER'])
+
 # Copy default config if not exists
 default = os.path.expanduser("~") + os.sep + '.rainbow_config.json'
 if not os.path.isfile(default):
     cmd = 'cp rainbowstream/colorset/config ' + default
+    os.system(cmd)
+    cmd = 'chown ' + quote(user) + ' ' + default
     os.system(cmd)
     cmd = 'chmod 777 ' + default
     os.system(cmd)


### PR DESCRIPTION
Set the proper file ownership if installed with sudo. This avoids
constants error messages when trying to change/delete configuration
values (chmod: changing permissions of ...: Operation not permitted)

Signed-off-by: Eliseo Ocampos <roskoff@gmail.com>