### PR TITLE
Fix garbled prompt when HIDE_PROMPT = False

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -218,7 +218,7 @@ def init(args):
     g['PREFIX'] = u2str(emojize(format_prefix()))
     g['full_name'] = name
     g['decorated_name'] = lambda x: color_func(
-        c['DECORATED_NAME'])('[' + x + ']: ', rl=True)
+        c['DECORATED_NAME'])('[' + x + ']: ')
     # Theme init
     files = os.listdir(os.path.dirname(__file__) + '/colorset')
     themes = [f.split('.')[0] for f in files if f.split('.')[-1] == 'json']


### PR DESCRIPTION
Avoid garbled prompt by using default value for readline
parameter (false). If happens to be true, control characters (SOH &
STX) got printed sorrounding prompt.

Signed-off-by: Eliseo Ocampos <roskoff@gmail.com>