### PR TITLE
Add LICENSE.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.rst
+include README.rst LICENSE.txt
 include rainbowstream/image.c
 recursive-include rainbowstream/colorset *


### PR DESCRIPTION
Add LICENSE.txt to MANIFEST.in so the file is included in the source
distribution created for releases on PyPI.

This enables downstream users and packagers to confirm the licensing of
the project, and include the license file (along with any Copyright
header the text also includes) into packages for distribution for users.