### PR TITLE
fix build for clean build environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,16 @@ install_requires = [
 ]
 
 # Default user (considers non virtualenv method)
-user = os.environ.get('SUDO_USER', os.environ['USER'])
+user = os.environ.get('SUDO_USER', os.environ.get('USER', None))
 
 # Copy default config if not exists
 default = os.path.expanduser("~") + os.sep + '.rainbow_config.json'
 if not os.path.isfile(default):
     cmd = 'cp rainbowstream/colorset/config ' + default
     os.system(cmd)
-    cmd = 'chown ' + quote(user) + ' ' + default
-    os.system(cmd)
+    if user:
+        cmd = 'chown ' + quote(user) + ' ' + default
+        os.system(cmd)
     cmd = 'chmod 777 ' + default
     os.system(cmd)
 


### PR DESCRIPTION
#### Motivation

If rainbowstream is built in an environment where `USER` or `SUDO_USER` are not set, the build will fails.

This PR fix the build for such environments and is needed to have rainbowstream building in Nix.

#### Example

Error traceback during a Nix build of 1.3.5:

```
Traceback (most recent call last):
  File "nix_run_setup.py", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 27, in <module>
    user = os.environ.get('SUDO_USER', os.environ['USER'])
  File "/nix/store/98k1k047r1lz1wk1h8ywcxldnrvhyql7-python-2.7.12/lib/python2.7/UserDict.py", line 40, in __getitem__
    raise KeyError(key)
KeyError: 'USER'
builder for ‘/nix/store/j3rgkcgz7hsiibcal69z4v6qpvkab7fh-python2.7-rainbowstream-1.3.5.drv’ failed with exit code 1
error: build of ‘/nix/store/j3rgkcgz7hsiibcal69z4v6qpvkab7fh-python2.7-rainbowstream-1.3.5.drv’ failed
```