### PR TITLE
Make use of modern-style quotes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -351,8 +351,9 @@ You also can view or set a new value of every config key by ``config`` command (
 -  ``QUOTE_FORMAT``: format when quote a tweet
 
     + ``#comment``: Your own comment about the tweet
-    + ``#owner``: owner's username with '@'
+    + ``#owner``: owner's username *without* '@'
     + ``#tweet``: original tweet
+    + ``#tid``: the tweet id on Twitter
 
 -  ``THREAD_META_LEFT``: format for meta information of messages from partner which is display in the left of screen.
 

--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -24,7 +24,7 @@
     // 'conversation': max tweet in a thread
     "CONVERSATION_MAX" : 30,
     // 'quote' format
-    "QUOTE_FORMAT" : "#comment RT #owner: #tweet",
+    "QUOTE_FORMAT" : "#comment https:\/\/twitter.com\/#owner\/status\/#tid",
     // 'thread' meta format
     "THREAD_META_LEFT" : "(#id) #clock",
     "THREAD_META_RIGHT" : "#clock (#id)",

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -1066,8 +1066,10 @@ def format_quote(tweet):
     Quoting format
     """
     # Retrieve info
-    screen_name = '@' + tweet['user']['screen_name']
-    text = tweet['text']
+    screen_name = str( tweet['user']['screen_name'] )
+    text        = str( tweet['text'] )
+    tid         = str( tweet['id'] )
+
     # Validate quote format
     if '#owner' not in c['QUOTE_FORMAT']:
         printNicely(light_magenta('Quote should contains #owner'))
@@ -1075,12 +1077,16 @@ def format_quote(tweet):
     if '#comment' not in c['QUOTE_FORMAT']:
         printNicely(light_magenta('Quote format should have #comment'))
         return False
+
     # Build formater
     formater = ''
     try:
         formater = c['QUOTE_FORMAT']
-        formater = screen_name.join(formater.split('#owner'))
-        formater = text.join(formater.split('#tweet'))
+
+        formater = formater.replace('#owner', screen_name)
+        formater = formater.replace('#tweet', text)
+        formater = formater.replace('#tid',   tid)
+
         formater = emojize(formater)
     except:
         pass

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -718,47 +718,82 @@ def delete():
 
 def show():
     """
-    Show image
+    Show something in the tweet
     """
     t = Twitter(auth=authen())
     try:
         target = g['stuff'].split()[0]
-        if target != 'image':
-            return
+
         id = int(g['stuff'].split()[1])
-        tid = c['tweet_dict'][id]
+        tid  = c['tweet_dict'][id]
         tweet = t.statuses.show(id=tid)
-        media = tweet['entities']['media']
-        for m in media:
-            res = requests.get(m['media_url'])
-            img = Image.open(BytesIO(res.content))
-            img.show()
+
+        if target in [ 'image' ]:
+            show_image( tweet )
+        if target in [ 'url', 'urls', 'link', 'links' ]:
+            show_url( tweet )
+
+        return
+
     except:
         debug_option()
-        printNicely(red('Sorry I can\'t show this image.'))
+        printNicely(red('Sorry I can\'t show this.'))
 
 
-def urlopen():
+def show_image(tweet):
+    """
+    Show image
+    """
+
+    media = tweet['entities']['media']
+
+    for m in media:
+        res = requests.get(m['media_url'])
+        img = Image.open(BytesIO(res.content))
+        img.show()
+
+
+def show_url(tweet):
     """
     Open url
     """
+
+    urls = tweet['entities']['urls']
+
+    if not urls:
+        printNicely(light_magenta('No url here @.@!'))
+        return
+    else:
+        for url in urls:
+            expanded_url = url['expanded_url']
+            webbrowser.open(expanded_url)
+
+
+def tweetopen():
+    """
+    Open tweet in browser
+    """
+
     t = Twitter(auth=authen())
+
     try:
         if not g['stuff'].isdigit():
             return
-        tid = c['tweet_dict'][int(g['stuff'])]
+
+        tid   = c['tweet_dict'][int(g['stuff'])]
         tweet = t.statuses.show(id=tid)
-        urls = tweet['entities']['urls']
-        if not urls:
-            printNicely(light_magenta('No url here @.@!'))
-            return
-        else:
-            for url in urls:
-                expanded_url = url['expanded_url']
-                webbrowser.open(expanded_url)
+        owner = tweet['user']['screen_name']
+
+        # Compute tweet URL
+        url = 'https://twitter.com/{owner}/status/{tid}' \
+                .format( owner = owner,
+                         tid   = tid )
+
+        webbrowser.open(url)
+
     except:
         debug_option()
-        printNicely(red('Sorry I can\'t open url in this tweet.'))
+        printNicely(red('Sorry I can\'t open this tweet.'))
 
 
 def inbox():
@@ -1925,7 +1960,7 @@ funcset = [
     search,
     message,
     show,
-    urlopen,
+    tweetopen,
     ls,
     inbox,
     thread,
@@ -1987,7 +2022,7 @@ def listen():
             [],  # url
             ['#'],  # search
             ['@'],  # message
-            ['image'],  # show image
+            ['image', 'url'],  # show image, show url
             [''],  # open url
             ['fl', 'fr'],  # list
             [],  # inbox


### PR DESCRIPTION
(See issue https://github.com/DTVD/rainbowstream/issues/134)

Twitter introduced a new way of quoting, by simply putting the tweet url
as a quote. The web interface (and most clients) will then display a
preview of the quoted tweet, leaving more characters available for your
quote.

This patch change the default quote format from the old mode ("#comment
RT #owner #text") to the new one, introducing a new #tid keyword holding
the tweet id (needed to find the tweet URL). It's still possible to go
back to the old mode, by changing the QUOTE_FORMAT config parameter
back to "#comment RT @#owner #text".