### PR TITLE
Make use of modern-style quotes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -351,8 +351,9 @@ You also can view or set a new value of every config key by ``config`` command (
 -  ``QUOTE_FORMAT``: format when quote a tweet
 
     + ``#comment``: Your own comment about the tweet
-    + ``#owner``: owner's username with '@'
+    + ``#owner``: owner's username *without* '@'
     + ``#tweet``: original tweet
+    + ``#tid``: the tweet id on Twitter
 
 -  ``THREAD_META_LEFT``: format for meta information of messages from partner which is display in the left of screen.
 

--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -24,7 +24,7 @@
     // 'conversation': max tweet in a thread
     "CONVERSATION_MAX" : 30,
     // 'quote' format
-    "QUOTE_FORMAT" : "#comment RT #owner: #tweet",
+    "QUOTE_FORMAT" : "#comment https:\/\/twitter.com\/#owner\/status\/#tid",
     // 'thread' meta format
     "THREAD_META_LEFT" : "(#id) #clock",
     "THREAD_META_RIGHT" : "#clock (#id)",

--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -24,7 +24,7 @@
     // 'conversation': max tweet in a thread
     "CONVERSATION_MAX" : 30,
     // 'quote' format
-    "QUOTE_FORMAT" : "#comment https:\/\/twitter.com\/#owner\/status\/#tid",
+    "QUOTE_FORMAT" : "#comment https://twitter.com/#owner/status/#tid",
     // 'thread' meta format
     "THREAD_META_LEFT" : "(#id) #clock",
     "THREAD_META_RIGHT" : "#clock (#id)",

--- a/rainbowstream/config.py
+++ b/rainbowstream/config.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 # Regular expression for comments in config file
 comment_re = re.compile(
-    '(^)?[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
+    '(^)[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
     re.DOTALL | re.MULTILINE
 )
 

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -1066,8 +1066,10 @@ def format_quote(tweet):
     Quoting format
     """
     # Retrieve info
-    screen_name = '@' + tweet['user']['screen_name']
-    text = tweet['text']
+    screen_name = str( tweet['user']['screen_name'] )
+    text        = str( tweet['text'] )
+    tid         = str( tweet['id'] )
+
     # Validate quote format
     if '#owner' not in c['QUOTE_FORMAT']:
         printNicely(light_magenta('Quote should contains #owner'))
@@ -1075,12 +1077,16 @@ def format_quote(tweet):
     if '#comment' not in c['QUOTE_FORMAT']:
         printNicely(light_magenta('Quote format should have #comment'))
         return False
+
     # Build formater
     formater = ''
     try:
         formater = c['QUOTE_FORMAT']
-        formater = screen_name.join(formater.split('#owner'))
-        formater = text.join(formater.split('#tweet'))
+
+        formater = formater.replace('#owner', screen_name)
+        formater = formater.replace('#tweet', text)
+        formater = formater.replace('#tid',   tid)
+
         formater = emojize(formater)
     except:
         pass

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -1066,8 +1066,8 @@ def format_quote(tweet):
     Quoting format
     """
     # Retrieve info
-    screen_name = str( tweet['user']['screen_name'] )
-    text        = str( tweet['text'] )
+    screen_name = tweet['user']['screen_name']
+    text        = tweet['text']
     tid         = str( tweet['id'] )
 
     # Validate quote format


### PR DESCRIPTION
(See issue https://github.com/DTVD/rainbowstream/issues/134)

Twitter introduced a new way of quoting, by simply putting the tweet url
as a quote. The web interface (and most clients) will then display a
preview of the quoted tweet, leaving more characters available for your
quote.

This patch change the default quote format from the old mode ("#comment
RT #owner #text") to the new one, introducing a new #tid keyword holding
the tweet id (needed to find the tweet URL). It's still possible to go
back to the old mode, by changing the QUOTE_FORMAT config parameter
back to "#comment RT @#owner #text".