### PR TITLE
removed https:// prefix from "QUOTE_FORMAT"

### DIFF
--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -24,7 +24,7 @@
     // 'conversation': max tweet in a thread
     "CONVERSATION_MAX" : 30,
     // 'quote' format
-    "QUOTE_FORMAT" : "#comment https://twitter.com/#owner/status/#tid",
+    "QUOTE_FORMAT" : "#comment twitter.com/#owner/status/#tid",
     // 'thread' meta format
     "THREAD_META_LEFT" : "(#id) #clock",
     "THREAD_META_RIGHT" : "#clock (#id)",


### PR DESCRIPTION
Upon trying to use this config file, rainbowstream threw the following error: "Your ~/.rainbow_config.json is messed up:
>>> Invalid control character at: line 27 column 38 (char 406)". I simply removed the https:// prefix from the url and it worked.