### PR TITLE
Add expansion of '~' to history path

### DIFF
--- a/rainbowstream/interactive.py
+++ b/rainbowstream/interactive.py
@@ -69,7 +69,7 @@ def read_history():
     Read history file
     """
     try:
-        readline.read_history_file(c['HISTORY_FILENAME'])
+        readline.read_history_file(os.path.expanduser(c['HISTORY_FILENAME']))
     except:
         pass
 
@@ -79,7 +79,7 @@ def save_history():
     Save history to file
     """
     try:
-        readline.write_history_file(c['HISTORY_FILENAME'])
+        readline.write_history_file(os.path.expanduser(c['HISTORY_FILENAME']))
     except:
         pass
 


### PR DESCRIPTION
The readline module cannot read/write histories from or to under '\~' without expansion of '\~'.

> Unlike a unix shell, Python does not do any automatic path expansions.
> [os.path](https://docs.python.jp/3/library/os.path.html)

I added expansion of '\~' so that readline reads/writes histories from/to same path regardless of the current directory.